### PR TITLE
Fix/9.0/profiler begin end date

### DIFF
--- a/profiler/__init__.py
+++ b/profiler/__init__.py
@@ -3,4 +3,5 @@
 # Copyright 2014 Anybox <http://anybox.fr>
 # Copyright 2016 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
 from . import controllers
+from . import models
 from .hooks import post_load

--- a/profiler/controllers/main.py
+++ b/profiler/controllers/main.py
@@ -21,7 +21,8 @@ from openerp.service.db import dump_db_manifest
 
 
 _logger = logging.getLogger(__name__)
-DFTL_LOG_PATH = "/var/lib/postgresql/%s/main/pg_log/postgresql.log"
+# TODO: Pull the log path from a System Parameter
+DFTL_LOG_PATH = "/var/lib/postgresql/data/pgdata/pg_log/postgresql.log"
 
 PGOPTIONS = (
     "-c client_min_messages=notice -c log_min_messages=warning "
@@ -136,7 +137,7 @@ class ProfilerController(http.Controller):
             return
         filename = os.path.join(dir_dump, output)
         pg_version = dump_db_manifest(cursor)["pg_version"]
-        log_path = os.environ.get("PG_LOG_PATH", DFTL_LOG_PATH % pg_version)
+        log_path = os.environ.get("PG_LOG_PATH", DFTL_LOG_PATH)
         if not os.path.exists(os.path.dirname(filename)):
             try:
                 os.makedirs(os.path.dirname(filename))

--- a/profiler/controllers/main.py
+++ b/profiler/controllers/main.py
@@ -68,7 +68,6 @@ class ProfilerController(http.Controller):
         ProfilerController.begin_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         ProfilerController.player_state = "profiler_player_enabled"
 
-        # BEGIN CUSTOM CODE
         profiler_obj = request.env["profiler.profiler"]
         user = request.env.user
 
@@ -79,7 +78,6 @@ class ProfilerController(http.Controller):
         # Create new profiler record for the current user
         profiler_id = profiler_obj.create({"user_id": user.id, "datetime_begin": ProfilerController.begin_date})
         request.env.cr.commit()
-        # END CUSTOM CODE
 
         os.environ["PGOPTIONS"] = PGOPTIONS
         self.empty_cursor_pool()
@@ -91,7 +89,6 @@ class ProfilerController(http.Controller):
         ProfilerController.end_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         ProfilerController.player_state = "profiler_player_disabled"
 
-        # BEGIN CUSTOM CODE
         profiler_obj = request.env["profiler.profiler"]
         user = request.env.user
 
@@ -102,7 +99,6 @@ class ProfilerController(http.Controller):
 
         profiler_id.datetime_end = ProfilerController.end_date
         request.env.cr.commit()
-        # END CUSTOM CODE
 
         os.environ.pop("PGOPTIONS", None)
         self.empty_cursor_pool()
@@ -179,7 +175,6 @@ class ProfilerController(http.Controller):
         exclude_query = self.get_exclude_query()
         dbname = cursor.dbname
 
-        # BEGIN CUSTOM CODE
         profiler_obj = request.env["profiler.profiler"]
         user = request.env.user
 
@@ -190,10 +185,9 @@ class ProfilerController(http.Controller):
             raise ValidationError(
                 _("Must have a Start Date ({}) and End Date ({}) to run pgbadger!".format(begin_date, end_date))
             )
-        # END CUSTOM CODE
 
         command = [
-            "sudo",  # CUSTOM CODE
+            "sudo",
             pgbadger,
             "-f",
             "stderr",
@@ -204,9 +198,9 @@ class ProfilerController(http.Controller):
             "-d",
             dbname,
             "-b",
-            begin_date,  # CUSTOM CODE
+            begin_date,
             "-e",
-            end_date,  # CUSTOM CODE
+            end_date,
             "--sample",
             "2",
             "--disable-type",

--- a/profiler/controllers/main.py
+++ b/profiler/controllers/main.py
@@ -193,6 +193,7 @@ class ProfilerController(http.Controller):
         # END CUSTOM CODE
 
         command = [
+            "sudo",  # CUSTOM CODE
             pgbadger,
             "-f",
             "stderr",

--- a/profiler/hooks.py
+++ b/profiler/hooks.py
@@ -71,8 +71,9 @@ def patch_stop():
     _logger.info("Patching openerp.service.server.ThreadedServer.stop")
 
     def stop(*args, **kwargs):
-        if openerp.tools.config["test_enable"]:
-            dump_stats()
+        # FIXME: Should this be allowed to apply always?
+        # if openerp.tools.config["test_enable"]:
+        dump_stats()
         return origin_stop(*args, **kwargs)
 
     ThreadedServer.stop = stop
@@ -82,8 +83,9 @@ def post_load():
     _logger.info("Post load")
     create_profile()
     patch_odoo()
-    if openerp.tools.config["test_enable"]:
-        # Enable profile in test mode for orm methods.
-        _logger.info("Enabling profiler and apply patch")
-        CoreProfile.enabled = True
-        patch_stop()
+    # FIXME: Should this be allowed to apply always?
+    # if openerp.tools.config['test_enable']:
+    # Enable profile in test mode for orm methods.
+    _logger.info("Enabling profiler and apply patch")
+    CoreProfile.enabled = True
+    patch_stop()

--- a/profiler/models/__init__.py
+++ b/profiler/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import profiler

--- a/profiler/models/profiler.py
+++ b/profiler/models/profiler.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from openerp import api, fields, models, _
+
+
+class ProfilerProfiler(models.TransientModel):
+    _name = "profiler.profiler"
+    _description = "Profiler"
+
+    datetime_begin = fields.Datetime(string="Begin Date")
+    datetime_end = fields.Datetime(string="End Date")
+    user_id = fields.Many2one("res.users", string="User")
+
+    _sql_constraints = [("profiler_user_unique", "unique(user_id)", "A user can only have one profiler.")]


### PR DESCRIPTION
**Previous Behavior**

* When clicking the `profiler`'s **Download stats** button (the save icon), the `pgbadger` command was (more often than not) being run without a _start date/time_ and/or _end date/time_.

**New Behavior**

* The **Start profiling** and **Stop profiling** buttons are now responsible for maintaining a `profiler.profiler` model record for each user.
* The **Download stats** button now refers to the user's `profiler.profiler` record to reference the profiler sessoin's _start date/time_ and _end date/time_.

---

As an example, I performed a very short profiler session where I tried to duplicate an `ir.config_parameter` entry, which raised an error due to a database constraint. Attached, you can this example's output: [`pgbadger` output](https://github.com/gobluestingray/odoo-profiler/files/3824957/pgbadger_output.txt) and the [`pstats_print2list` output](https://github.com/gobluestingray/odoo-profiler/files/3824959/openerp_2019-11-08_14-30-26.txt). The `pstats_print2list.stats` file is not included because Github does not allow attaching that filetype.

~I am in the process of cleaning up~ I set up [the Odoo Profiler page](https://wiki.bluestingray.com/doku.php?id=teams:erp:tools:profiler) on our wiki, which includes instructions on how to set up our `docker` containers to support profiling. ~I will update this PR once that is ready.~

Currently, you should be able to follow those instructions to get your containers configured, `profiler` installed, begin profiling some actions, and viewing the output logs. The [Analyzing Profiler Results](https://wiki.bluestingray.com/doku.php?id=teams:erp:tools:profiler#analyzing_profiler_results) section is not yet written, but I will be adding to it shortly.